### PR TITLE
Fix JSON parsing of auth key IPs

### DIFF
--- a/app/Model/AuthKey.php
+++ b/app/Model/AuthKey.php
@@ -109,14 +109,22 @@ class AuthKey extends AppModel
     {
         foreach ($results as $key => $val) {
             if (isset($val['AuthKey']['allowed_ips'])) {
-                $results[$key]['AuthKey']['allowed_ips'] = JsonTool::decode($val['AuthKey']['allowed_ips']);
+                try {
+                    $results[$key]['AuthKey']['allowed_ips'] = JsonTool::decode($val['AuthKey']['allowed_ips']);
+                } catch (JsonException $e) {
+                    $results[$key]['AuthKey']['allowed_ips'] = array_map('trim', explode(',', $val['AuthKey']['allowed_ips']));
+                }
             }
             if (isset($val['AuthKey']['unique_ips'])) {
-                $results[$key]['AuthKey']['unique_ips'] = JsonTool::decode($val['AuthKey']['unique_ips']);
+                try {
+                    $results[$key]['AuthKey']['unique_ips'] = JsonTool::decode($val['AuthKey']['unique_ips']);
+                } catch (JsonException $e) {
+                    $results[$key]['AuthKey']['unique_ips'] = array_map('trim', explode(',', $val['AuthKey']['unique_ips']));
+                }
             } else {
                 $results[$key]['AuthKey']['unique_ips'] = [];
             }
-            
+
         }
         return $results;
     }


### PR DESCRIPTION
## Summary
- avoid fatal error when stored auth key IP list is invalid JSON

## Testing
- `./Vendor/bin/parallel-lint --exclude Lib/cakephp/ --exclude Vendor/ -e php,ctp .`
- `./Vendor/bin/phpunit Test/` *(fails: Crypt_GPG_FileException)*
- `bash -x ./tests/build-test.sh` *(fails: ZeroMQ library could not be imported)*

------
